### PR TITLE
LINE accessToken をサーバーに送信

### DIFF
--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -3,24 +3,42 @@ import 'package:http/http.dart' as http;
 import 'package:my_app/model/todo.dart';
 import 'package:my_app/model/category.dart';
 import 'package:my_app/services_locator.dart';
+import 'package:my_app/services/authentication.dart';
 import 'package:my_app/services/configuration.dart';
 
 /// API Service
 class APIService {
+  final _auth = servicesLocator<AuthService>();
   final _config = servicesLocator<ConfigurationService>();
 
   String _apiUrl;
   int _apiVersion;
   String _apiRootUrl;
+  String _authorizationHeaderName;
+
   // initialize
   APIService() {
     _apiRootUrl = _config.apiRootUrl;
     _apiVersion = _config.apiVersion;
     _apiUrl = '$_apiRootUrl/api/v$_apiVersion';
+    _authorizationHeaderName = _config.authorizationHeaderName;
   }
 
   /// url to request API
   String requestUrl(String endpoint) => '$_apiUrl$endpoint';
+
+  /// HTTP Request Headers required to connect with API Server
+  Future<Map<String, String>> authorizedHeader() async {
+    final idToken = await _auth.accessToken;
+    return {_authorizationHeaderName: idToken};
+  }
+
+  /// HTTP Request Headers to send data to the API server
+  Future<Map<String, String>> authorizedHeaderWithJson() async {
+    var headers = await authorizedHeader();
+    headers['Content-Type'] = 'application/json; charset=UTF-8';
+    return headers;
+  }
 
   /// データ整形
   /// parseCategories
@@ -38,9 +56,11 @@ class APIService {
     // if (!isReady) return null;
     final endpoint = '/categories';
     final url = requestUrl(endpoint);
+    final headers = await authorizedHeader();
+    print(headers);
 
     // final response = await http.get(url, headers: headers);
-    final response = await http.get(url);
+    final response = await http.get(url, headers: headers);
 
     if (response.statusCode != 200) return null;
 

--- a/lib/services/authentication.dart
+++ b/lib/services/authentication.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_line_sdk/flutter_line_sdk.dart';
+
+import 'package:my_app/services_locator.dart';
+import 'package:my_app/services/navigation.dart';
+
+class AuthService {
+  final _navigation = servicesLocator<NavigationService>();
+
+  String access_token = "";
+  String get accessToken => access_token;
+
+  Future lineLogin() async {
+    try {
+      final result = await LineSDK.instance.login();
+      // user name -> result.userProfile.displayName
+      // user avatar -> result.userProfile.pictureUrl
+      // etc...
+      access_token = result.accessToken.value;
+      _navigation.pushAndReplace(routeName: '/root');
+    } on PlatformException catch (e) {
+      // Error handling.
+      print(e);
+    }
+  }
+}

--- a/lib/services/configuration.dart
+++ b/lib/services/configuration.dart
@@ -6,4 +6,7 @@ class ConfigurationService {
 
   /// apiVersion
   int get apiVersion => 1;
+  String get authorizationHeaderName {
+    return 'LINEAuthorization';
+  }
 }

--- a/lib/services_locator.dart
+++ b/lib/services_locator.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 
 import 'package:my_app/services/api.dart';
+import 'package:my_app/services/authentication.dart';
 import 'package:my_app/services/startup.dart';
 import 'package:my_app/services/navigation.dart';
 import 'package:my_app/services/configuration.dart';
@@ -16,6 +17,7 @@ void setupServiceLocator() {
   // LazySingleton refers to a class whose resource will not be initialised
   // until its used for the 1st time.
   // It's generally used to save resources and memory
+  servicesLocator.registerLazySingleton(() => AuthService());
   servicesLocator.registerLazySingleton(() => APIService());
   servicesLocator.registerLazySingleton(() => NavigationService());
   servicesLocator.registerLazySingleton(() => StartupService());

--- a/lib/ui/sign_in/sign_in_view.dart
+++ b/lib/ui/sign_in/sign_in_view.dart
@@ -22,7 +22,7 @@ class _SignInViewState extends State<SignInView> {
     return RaisedButton(
       child: const Text('Login'),
       color: Theme.of(context).primaryColor,
-      onPressed: model.lineLogin,
+      onPressed: model.login,
     );
   }
 }

--- a/lib/ui/sign_in/sign_in_viewmodel.dart
+++ b/lib/ui/sign_in/sign_in_viewmodel.dart
@@ -1,25 +1,14 @@
+import 'package:my_app/services/authentication.dart';
 import 'package:stacked/stacked.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_line_sdk/flutter_line_sdk.dart';
 
 import 'package:my_app/services_locator.dart';
-import 'package:my_app/services/navigation.dart';
+import 'package:my_app/services/authentication.dart';
 
 /// SignInViewModel
 class SignInViewModel extends BaseViewModel {
-  final _navigation = servicesLocator<NavigationService>();
+  final _auth = servicesLocator<AuthService>();
 
-  void lineLogin() async {
-    try {
-      final result = await LineSDK.instance.login();
-      // user id -> result.userProfile.userId
-      // user name -> result.userProfile.displayName
-      // user avatar -> result.userProfile.pictureUrl
-      // etc...
-      _navigation.pushAndReplace(routeName: '/root');
-    } on PlatformException catch (e) {
-      // Error handling.
-      print(e);
-    }
+  void login() async {
+    await _auth.lineLogin();
   }
 }


### PR DESCRIPTION
## 概要
サーバーとの通信時に `LINE accessToken` を用いて認証を行うようにした．
また ログイン機能をService に移行した．

## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
[flutter_line_sdk GitHub](https://github.com/line/flutter_line_sdk/blob/master/lib/src/model/login_result.dart#L40)
```
# lib/src/model/login_result.dart:40
AccessToken get accessToken => _accessToken;
```
[flutter_line_sdk GitHub](https://github.com/line/flutter_line_sdk/blob/master/lib/src/model/access_token.dart#L50)
```
# lib/src/model/access_token.dart:50
String get value => _data['access_token'];
```

当初は idToken を取得したかったが,
LINE Developers で `OpenID` の設定を行う必要があった
設定をすると個人情報をかなり取得するため申請が必要であった
→ 今度申請して機能を更新します．
```
String get idTokenNonce => _data['IDTokenNonce'];
```