### PR TITLE
ApiServerから Wish を取得

### DIFF
--- a/lib/model/wish.dart
+++ b/lib/model/wish.dart
@@ -1,0 +1,20 @@
+class Wish {
+  /// id
+  final int id;
+
+  /// 名称
+  final String name;
+
+  /// 欲しい度
+  final int star;
+
+  /// Constructor
+  Wish({this.id, this.name, this.star});
+
+  factory Wish.fromJson(Map<String, dynamic> json) {
+    return Wish(
+        id: json['id'] as int,
+        name: json['name'] as String,
+        star: json['star'] as int);
+  }
+}

--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:my_app/model/todo.dart';
 import 'package:my_app/model/category.dart';
 import 'package:my_app/model/user.dart';
+import 'package:my_app/model/wish.dart';
 import 'package:my_app/services_locator.dart';
 import 'package:my_app/services/authentication.dart';
 import 'package:my_app/services/configuration.dart';
@@ -73,7 +74,7 @@ class APIService {
   /// データ整形
   /// parseCategories
   List<Category> parseCategories(String responseBody) {
-    final data = json.decode(responseBody)['categories'];
+    final data = json.decode(responseBody)['data'];
     final categories = data
         .map<Category>(
             (json) => Category.fromJson(json as Map<String, dynamic>))
@@ -93,6 +94,31 @@ class APIService {
     if (response.statusCode != 200) return null;
 
     return parseCategories(response.body);
+  }
+
+  /// データ整形
+  List<Wish> parseWishes(String responseBody) {
+    final data = json.decode(responseBody)['data'];
+    final wishes = data
+        .map<Wish>((json) => Wish.fromJson(json as Map<String, dynamic>))
+        .toList() as List<Wish>;
+    return wishes;
+  }
+
+  /// getWishes
+  Future<List<Wish>> getWishes(int category_id) async {
+    final uid = await _auth.uid;
+
+    final endpoint = '/users/$uid/wishes?category_id=$category_id';
+    final url = requestUrl(endpoint);
+    final headers = await authorizedHeader();
+
+    final response = await http.get(url, headers: headers);
+    print(response.body);
+
+    if (response.statusCode != 200) return null;
+
+    return parseWishes(response.body);
   }
 
   /// getTodos Fakefunction

--- a/lib/ui/category/category_view.dart
+++ b/lib/ui/category/category_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:stacked/stacked.dart';
 
 import 'package:my_app/model/category.dart';
+import 'package:my_app/model/wish.dart';
 import 'package:my_app/ui/category/category_viewmodel.dart';
 import 'package:my_app/shared/loading.dart';
 
@@ -17,7 +18,6 @@ class CategoryView extends StatelessWidget {
   }
 
   Widget _categoryView(CategoryViewModel model, Size screenSize) {
-    final categories = model.categories;
     final category_tabs = model.category_tabs;
     return DefaultTabController(
       length: category_tabs.length,
@@ -35,25 +35,27 @@ class CategoryView extends StatelessWidget {
                   ))),
           body: TabBarView(
               children: category_tabs
-                  .map((tab) => _categoryList(model, tab.text))
+                  .map((tab) => _wishList(model, tab.text))
                   .toList())),
     );
   }
 
-  Widget _categoryList(CategoryViewModel model, String name) {
-    final categories = model.categories;
+  Widget _wishList(CategoryViewModel model, String category_name) {
+    final wishes = model.wishes[category_name];
+    print(wishes);
+
     return ListView.builder(
         shrinkWrap: true,
         physics: NeverScrollableScrollPhysics(),
         padding: EdgeInsets.all(8),
-        itemCount: categories.length,
-        itemBuilder: (context, i) => _categoryTile(categories[i]));
+        itemCount: wishes.length,
+        itemBuilder: (context, i) => _wishTile(wishes[i]));
   }
 
-  Widget _categoryTile(Category category) {
+  Widget _wishTile(Wish wish) {
     return Card(
       child: ListTile(
-        title: Text(category.name),
+        title: Text(wish.name),
       ),
     );
   }

--- a/lib/ui/category/category_viewmodel.dart
+++ b/lib/ui/category/category_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:stacked/stacked.dart';
 
 import 'package:my_app/model/category.dart';
+import 'package:my_app/model/wish.dart';
 import 'package:my_app/services_locator.dart';
 import 'package:my_app/services/api.dart';
 
@@ -10,6 +11,7 @@ class CategoryViewModel extends BaseViewModel {
 
   /// categories
   List<Category> categories = [];
+  Map<String, List<Wish>> wishes = {};
   List<Tab> category_tabs = [];
 
   Future<void> initialize() async {
@@ -18,6 +20,16 @@ class CategoryViewModel extends BaseViewModel {
     final getCategoriesFromApi = await _api.getCategories();
     categories = getCategoriesFromApi;
     await setTabs();
+
+    /// TODO: リファクタリング 思い処理してる
+    for (Category category in categories) {
+      final category_id = category.id;
+      print("wish #GET request ${category_id}");
+      final getWishesFromApi = await _api.getWishes(category_id);
+      wishes[category.name] = getWishesFromApi;
+    }
+    print(wishes);
+
     setBusy(false);
   }
 


### PR DESCRIPTION
## 概要
サーバーから `Wish`を取得する機能を実装した
タブで選択したページに応じて wish を表示する．
<img width="40%" alt="スクリーンショット 2021-02-21 20 30 28" src="https://user-images.githubusercontent.com/51741264/108624119-20395500-7486-11eb-92e1-36c293c48de3.png">

## 詳細（主に技術的変更点）
うまい実装が思いつかなかったのでここで何回もリクエストをしてる
→ サーバー側の処理を変えるか，flutter側で処理を変える必要あり（たぶんサーバー）
```dart
/// TODO: リファクタリング 重い処理してる
for (Category category in categories) {
  final category_id = category.id;
  print("wish #GET request ${category_id}");
  final getWishesFromApi = await _api.getWishes(category_id);
  wishes[category.name] = getWishesFromApi;
}
```

## 保留した項目・TODOリスト
- [ ] カテゴリーごとにまとめてサーバーで値を返す（Categoryの数に応じて動的に）

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
