### PR TITLE
カテゴリー取得 api を更新

### DIFF
--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -114,8 +114,11 @@ class APIService {
   /// データ整形
   Map<String, List<Wish>> parseWishes(String responseBody) {
     final data = json.decode(responseBody)['data'];
-    final wishes = data.forEach((key, value) {
-      value
+
+    /// TODO: リファクタリング
+    final Map<String, List<Wish>> wishes = new Map();
+    data.forEach((key, value) {
+      wishes[key] = value
           .map<Wish>((json) => Wish.fromJson(json as Map<String, dynamic>))
           .toList() as List<Wish>;
     });

--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -112,19 +112,21 @@ class APIService {
   }
 
   /// データ整形
-  List<Wish> parseWishes(String responseBody) {
+  Map<String, List<Wish>> parseWishes(String responseBody) {
     final data = json.decode(responseBody)['data'];
-    final wishes = data
-        .map<Wish>((json) => Wish.fromJson(json as Map<String, dynamic>))
-        .toList() as List<Wish>;
+    final wishes = data.forEach((key, value) {
+      value
+          .map<Wish>((json) => Wish.fromJson(json as Map<String, dynamic>))
+          .toList() as List<Wish>;
+    });
     return wishes;
   }
 
   /// getWishes
-  Future<List<Wish>> getWishes(int category_id) async {
+  Future<Map<String, List<Wish>>> getWishes() async {
     final uid = await _auth.uid;
 
-    final endpoint = '/users/$uid/wishes?category_id=$category_id';
+    final endpoint = '/users/$uid/wishes';
     final url = requestUrl(endpoint);
     final headers = await authorizedHeader();
 

--- a/lib/services/configuration.dart
+++ b/lib/services/configuration.dart
@@ -1,8 +1,8 @@
 class ConfigurationService {
   /// apiRootUrl
   String get apiRootUrl {
-    // return 'https://wishapp-api.herokuapp.com';
-    return 'http://localhost:3000';
+    return 'https://wishapp-api.herokuapp.com';
+    // return 'http://localhost:3000';
   }
 
   /// apiVersion

--- a/lib/ui/category/category_viewmodel.dart
+++ b/lib/ui/category/category_viewmodel.dart
@@ -21,14 +21,8 @@ class CategoryViewModel extends BaseViewModel {
     categories = getCategoriesFromApi;
     await setTabs();
 
-    /// TODO: リファクタリング 思い処理してる
-    for (Category category in categories) {
-      final category_id = category.id;
-      print("wish #GET request ${category_id}");
-      final getWishesFromApi = await _api.getWishes(category_id);
-      wishes[category.name] = getWishesFromApi;
-    }
-    print(wishes);
+    final getWishesFromApi = await _api.getWishes();
+    wishes = getWishesFromApi;
 
     setBusy(false);
   }


### PR DESCRIPTION
## 概要
これまでカテゴリーごとにリクエストを出していたが，処理がかなり重いため，
一度で全てのカテゴリーを取得するように実装した．（サーバー側も同時に更新）

取得したデータを格納する処理で以下のような処理を行なっている．
ここの処理をもう少し綺麗に書く必要があると感じたので TODO
```dart
  /// データ整形
  Map<String, List<Wish>> parseWishes(String responseBody) {
    final data = json.decode(responseBody)['data'];

    /// TODO: リファクタリング
    final Map<String, List<Wish>> wishes = new Map();
    data.forEach((key, value) {
      wishes[key] = value
          .map<Wish>((json) => Wish.fromJson(json as Map<String, dynamic>))
          .toList() as List<Wish>;
    });
    return wishes;
  }

```

## 保留した項目・TODOリスト
- [ ] parseWishes リファクタリング

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
